### PR TITLE
Use consistent index js and css filenames

### DIFF
--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -1,7 +1,7 @@
 import { useState, MutableRefObject, useEffect } from 'react';
 import { log } from '../utils';
 import { ParamDataType, ParameterType } from '../types/ParametersResponse';
-import { DataObjectType, DashboardType, DataCatalogType, OutputFormatEnum, ModelType, DatasetType, LineageType, DataTypeType, ConnectionType } from '../types/DataCatalogResponse';
+import { DataObjectType, DashboardType, DataCatalogType, OutputFormatEnum, ModelType, DatasetType, LineageType, DataTypeType, ConnectionType, ConfigurablesType } from '../types/DataCatalogResponse';
 
 
 interface SettingsProps {
@@ -18,11 +18,12 @@ interface SettingsProps {
     setModels: (x: ModelType[]) => void;
     setConnections: (x: ConnectionType[]) => void;
     setLineageData: (x: LineageType[]) => void;
+    setConfigurables: (x: ConfigurablesType[]) => void;
 }
 
 export default function Settings({ 
     projectMetadataPath, parametersURL, resultsURL, fetchJson, setParamData, clearTableData, setOutputFormat, isAdmin, 
-    dataMode, toggleDataMode, setModels, setConnections, setLineageData
+    dataMode, toggleDataMode, setModels, setConnections, setLineageData, setConfigurables
 }: SettingsProps) {
 
     const [datasetsObjList, setDatasetsObjList] = useState<DatasetType[]>([]);
@@ -40,6 +41,7 @@ export default function Settings({
             setDatasetsObjList(x.datasets);
             setDashboardsObjList(x.dashboards);
             setLineageData(x.lineage);
+            setConfigurables(x.configurables || []);
         });
     }, [fetchJson]);
 

--- a/src/pages/ExplorerPage.css
+++ b/src/pages/ExplorerPage.css
@@ -1,10 +1,5 @@
 /* Styles specific to the Explorer page */
 
-.config-input {
-  max-width: 80px;
-  padding: 6px 10px;
-}
-
 /* Update the menu styles */
 .menu-panel {
   position: absolute;
@@ -69,11 +64,13 @@
   color: var(--text);
   white-space: nowrap;
   margin: 0;
+  flex: 1;
 }
 
 .menu-config-item input {
-  width: 100%;
+  flex: 1;
   margin: 0;
+  padding: 6px 10px;
 }
 
 .resize-handle {

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,8 +1,7 @@
 import { useState, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 import LoadingSpinner from '../components/LoadingSpinner';
 import './LoginPage.css';
-import { getHashParams, getProjectMetadataPath, getProjectRelatedQueryParams } from '../utils';
 import { useApp } from '../Router';
 
 interface Provider {
@@ -14,7 +13,8 @@ interface Provider {
 
 export default function LoginPage() {
   const navigate = useNavigate();
-  const { logout } = useApp();
+  const location = useLocation();
+  const { hostname, projectName, projectVersion, projectMetadataPath, logout } = useApp();
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState('');
   const [providers, setProviders] = useState<Provider[]>([]);
@@ -23,14 +23,7 @@ export default function LoginPage() {
     password: ''
   });
 
-  const searchParams = getHashParams();
-  const hostname = searchParams.get('host');
-  const projectName = searchParams.get('projectName');
-  const projectVersion = searchParams.get('projectVersion');
-
-  const projectMetadataPath = getProjectMetadataPath(projectName, projectVersion);
-  const projectRelatedQueryParams = getProjectRelatedQueryParams(hostname, projectName, projectVersion);
-  const targetRedirectPath = searchParams.get('redirectPath') || `/explorer?${projectRelatedQueryParams}`;
+  const targetRedirectPath = `/explorer${location.search || ''}`;
   const redirectUrl = `${window.location.origin}/squirrels-studio-v1/#${targetRedirectPath}`;
 
   useEffect(() => {
@@ -38,10 +31,10 @@ export default function LoginPage() {
   }, [logout]);
 
   useEffect(() => {
-    if (!hostname || !projectMetadataPath) {
+    if (!projectMetadataPath) {
       navigate('/');
     }
-  }, [hostname, projectMetadataPath, navigate]);
+  }, [projectMetadataPath, navigate]);
 
   useEffect(() => {
     const fetchProviders = async () => {
@@ -70,7 +63,7 @@ export default function LoginPage() {
   };
 
   const handleGuestAccess = () => {
-    navigate(`/explorer?${projectRelatedQueryParams}`);
+    navigate(targetRedirectPath);
   };
 
   const handleSubmit = async (event: React.FormEvent) => {

--- a/src/pages/RootPage.tsx
+++ b/src/pages/RootPage.tsx
@@ -21,6 +21,14 @@ export default function RootPage() {
     sessionStorage.removeItem('isAdmin');
   }, []);
 
+  // If DEFAULT_* globals are defined, redirect to login with those params
+  useEffect(() => {
+    const { DEFAULT_PROJECT_NAME, DEFAULT_PROJECT_VERSION } = window;
+    if (DEFAULT_PROJECT_NAME && DEFAULT_PROJECT_VERSION) {
+      navigate(`/login`);
+    }
+  }, [navigate]);
+
   const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = event.target;
     setFormData((prevFormData) => ({
@@ -41,6 +49,9 @@ export default function RootPage() {
         throw new Error('Host URL must start with http:// or https://');
       }
       const projectMetadataPath = getProjectMetadataPath(formData.projectName, formData.projectVersion);
+      if (!projectMetadataPath) {
+        throw new Error('Project name and version are required');
+      }
       const response = await fetch(formData.hostname + projectMetadataPath);
       if (!response.ok) {
         throw new Error(`Connection failed: ${response.status} ${response.statusText}`);
@@ -76,7 +87,6 @@ export default function RootPage() {
               value={formData.hostname}
               onChange={handleInputChange}
               placeholder="e.g. http://localhost:4465"
-              required
             />
           </div>
           
@@ -90,7 +100,6 @@ export default function RootPage() {
               value={formData.projectName}
               onChange={handleInputChange}
               placeholder="Enter project name"
-              required
             />
           </div>
           
@@ -104,7 +113,6 @@ export default function RootPage() {
               value={formData.projectVersion}
               onChange={handleInputChange}
               placeholder="e.g. v1"
-              required
             />
           </div>
           

--- a/src/pages/UserManagementPage.tsx
+++ b/src/pages/UserManagementPage.tsx
@@ -32,7 +32,7 @@ export default function UserManagementPage() {
   const [editUserData, setEditUserData] = useState<Record<string, any>>({});
 
   useEffect(() => {
-    if (!hostname || !projectMetadataPath) {
+    if (!projectMetadataPath) {
       navigate('/');
     }
     
@@ -40,7 +40,7 @@ export default function UserManagementPage() {
       fetchUsers();
       fetchUserFields();
     }
-  }, [hostname, projectMetadataPath, isAuthenticated, navigate]);
+  }, [projectMetadataPath, isAuthenticated, navigate]);
 
   const fetchUsers = async () => {
     setIsLoading(true);

--- a/src/pages/UserSettingsPage.tsx
+++ b/src/pages/UserSettingsPage.tsx
@@ -43,12 +43,12 @@ export default function UserSettingsPage() {
 
   // Add useEffect for navigation
   useEffect(() => {
-    if (!hostname || !projectName || !projectVersion) {
+    if (!projectName || !projectVersion) {
       navigate('/');
     }
-  }, [hostname, projectName, projectVersion, isAuthenticated, navigate]);
+  }, [projectName, projectVersion, isAuthenticated, navigate]);
 
-  if (!hostname || !projectName || !projectVersion) {
+  if (!projectName || !projectVersion) {
     return null;
   }
 

--- a/src/types/DataCatalogResponse.tsx
+++ b/src/types/DataCatalogResponse.tsx
@@ -61,6 +61,13 @@ export interface LineageType {
     target: LineageNodeType;
 }
 
+export interface ConfigurablesType {
+    name: string;
+    label: string;
+    description: string;
+    default: string;
+}
+
 export interface DataCatalogType {
     parameters: ParameterType[];
     datasets: DatasetType[];
@@ -68,4 +75,5 @@ export interface DataCatalogType {
     connections: ConnectionType[];
     models: ModelType[];
     lineage: LineageType[];
+    configurables?: ConfigurablesType[];
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,20 +8,11 @@ export function log(...data: any[]) {
   }
 }
 
-export function getHashParams(): URLSearchParams {
-  const hash = window.location.hash;
-  const queryIndex = hash.indexOf('?');
-  return new URLSearchParams(queryIndex >= 0 ? hash.substring(queryIndex + 1) : '');
-}
-
-export function getProjectMetadataPath(projectName: string | null, projectVersion: string | null): string | null {
-  if (!projectName || !projectVersion) {
-    return null;
-  }
+export function getProjectMetadataPath(projectName: string | null, projectVersion: string | null): string {
   return `/api/squirrels-v0/project/${projectName}/${projectVersion}`;
 }
 
-export function getProjectRelatedQueryParams(hostname: string | null, projectName: string | null, projectVersion: string | null): string {
+export function getProjectRelatedQueryParams(hostname: string, projectName: string, projectVersion: string): string {
   if (!hostname || !projectName || !projectVersion) {
     return "";
   }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,12 +8,11 @@ export default defineConfig({
   build: {
     rollupOptions: {
       output: {
-        inlineDynamicImports: true,
-        entryFileNames: 'index.js',
-        chunkFileNames: 'index.js',
+        entryFileNames: 'assets/index.js',
         assetFileNames: (assetInfo) => {
-          if (assetInfo.name && assetInfo.name.endsWith('.css')) {
-            return 'index.css'
+          const isCss = assetInfo.originalFileNames.some((n) => typeof n === 'string' && /\.css$/i.test(n))
+          if (isCss) {
+            return 'assets/index.css'
           }
           return 'assets/[name][extname]'
         },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,4 +5,22 @@ import react from '@vitejs/plugin-react'
 export default defineConfig({
   plugins: [react()],
   base: '/squirrels-studio-v1/',
+  build: {
+    rollupOptions: {
+      output: {
+        inlineDynamicImports: true,
+        entryFileNames: 'index.js',
+        chunkFileNames: 'index.js',
+        assetFileNames: (assetInfo) => {
+          if (assetInfo.name && assetInfo.name.endsWith('.css')) {
+            return 'index.css'
+          }
+          return 'assets/[name][extname]'
+        },
+      },
+    },
+    // Force single bundle so all JS goes to index.js
+    cssCodeSplit: false,
+    modulePreload: false,
+  },
 })


### PR DESCRIPTION
Configure Vite to output built JS and CSS files as `index.js` and `index.css`.

---
<a href="https://cursor.com/background-agent?bcId=bc-ae4820dc-1501-4d2c-a589-b729e0ceb115">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ae4820dc-1501-4d2c-a589-b729e0ceb115">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

